### PR TITLE
part of https://app.zenhub.com/workspaces/smartcolumbusos-5d08f55f08ccbe75911ce796/issues/smartcolumbusos/scosopedia/142

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN npm test
 
 FROM nginx
 RUN apt-get -y update &&\
-    apt-get install -y nginx-extras
+    apt-get install -y nginx-extras &&\
+    rm /etc/nginx/sites-enabled/default
 COPY --from=builder /app/src/dist /usr/share/nginx/html
 COPY --from=builder /app/src/run.sh /run.sh
 COPY --from=builder /app/src/nginx-default.conf /etc/nginx/conf.d/default.conf.tpl

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN npm run build
 RUN npm test
 
 FROM nginx
+RUN apt-get -y update &&\
+    apt-get install -y nginx-extras
 COPY --from=builder /app/src/dist /usr/share/nginx/html
 COPY --from=builder /app/src/run.sh /run.sh
 COPY --from=builder /app/src/nginx-default.conf /etc/nginx/conf.d/default.conf.tpl

--- a/nginx-default.conf
+++ b/nginx-default.conf
@@ -9,6 +9,8 @@ server {
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' *.smartcolumbusos.com ${ADDITIONAL_CSP_HOSTS} *.amazonaws.com *.mapbox.com *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' *.smartcolumbusos.com ${ADDITIONAL_CSP_HOSTS} *.auth0.com *.mapbox.com *.plot.ly; worker-src blob:; block-all-mixed-content";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
 
+    more_clear_headers Server;
+
     gzip on;
     gzip_static on;
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;


### PR DESCRIPTION
https://app.zenhub.com/workspaces/smartcolumbusos-5d08f55f08ccbe75911ce796/issues/smartcolumbusos/scosopedia/142 is a card to disable or obfuscate all HTTP headers that disclose server information.

Added nginx-extras to dockerfile so I could use its more_clear_headers directive in nginx-default.conf. This clears the server header.